### PR TITLE
Add Neo4j test example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # neo4jtest
+
+This example demonstrates how to use the official `neo4j` Python driver to load a
+simple dependency graph of modules and functions.
+
+## Requirements
+
+- Python 3.8+
+- `neo4j` Python package
+- A running Neo4j instance accessible via Bolt (e.g. `bolt://localhost:7687`)
+
+Install the driver with:
+
+```bash
+pip install neo4j
+```
+
+Set the connection details via environment variables if needed:
+
+```bash
+export NEO4J_URI=bolt://localhost:7687
+export NEO4J_USER=neo4j
+export NEO4J_PASSWORD=test
+```
+
+## Running
+
+Execute the script to reset the database, create nodes and relationships, and
+query nodes connected to module `A`:
+
+```bash
+python test_neo4j.py
+```
+
+The output will list the nodes connected to module A.

--- a/test_neo4j.py
+++ b/test_neo4j.py
@@ -1,0 +1,59 @@
+from neo4j import GraphDatabase
+import os
+
+URI = os.getenv('NEO4J_URI', 'bolt://localhost:7687')
+USER = os.getenv('NEO4J_USER', 'neo4j')
+PASSWORD = os.getenv('NEO4J_PASSWORD', 'test')
+
+class Neo4jExample:
+    def __init__(self, uri, user, password):
+        self.driver = GraphDatabase.driver(uri, auth=(user, password))
+
+    def close(self):
+        self.driver.close()
+
+    def clear(self):
+        with self.driver.session() as session:
+            session.run("MATCH (n) DETACH DELETE n")
+
+    def create_nodes_and_relationships(self):
+        with self.driver.session() as session:
+            session.run("CREATE (:Module {name: 'A'})")
+            session.run("CREATE (:Module {name: 'B'})")
+            session.run("CREATE (:Function {name: 'foo'})")
+            session.run("CREATE (:Module {name: 'C'})")
+            session.run(
+                "MATCH (a:Module {name:'A'}), (b:Module {name:'B'}) "
+                "CREATE (a)-[:IMPORTS]->(b)"
+            )
+            session.run(
+                "MATCH (c:Module {name:'C'}), (a:Module {name:'A'}) "
+                "CREATE (c)-[:IMPORTS]->(a)"
+            )
+            session.run(
+                "MATCH (b:Module {name:'B'}), (f:Function {name:'foo'}) "
+                "CREATE (b)-[:DECLARES]->(f)"
+            )
+
+    def query_connected_to_a(self):
+        with self.driver.session() as session:
+            result = session.run(
+                "MATCH (a:Module {name: 'A'})--(n) RETURN n.name as name, labels(n) as labels"
+            )
+            return [(record['name'], record['labels']) for record in result]
+
+def main():
+    app = Neo4jExample(URI, USER, PASSWORD)
+    try:
+        print("Clearing database...")
+        app.clear()
+        print("Creating nodes and relationships...")
+        app.create_nodes_and_relationships()
+        print("Nodes connected to Module A:")
+        for name, labels in app.query_connected_to_a():
+            print(f" - {name} ({', '.join(labels)})")
+    finally:
+        app.close()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create a basic example `test_neo4j.py` showing how to use the `neo4j` driver
- update README with setup and run instructions

## Testing
- `python test_neo4j.py --help` *(fails: ModuleNotFoundError: No module named 'neo4j')*

------
https://chatgpt.com/codex/tasks/task_e_68874821cc3083208656f5cfbb971d36